### PR TITLE
Display in between percentages as a fade from base to progress

### DIFF
--- a/octoprint_ws281x_led_status/effects/progress.py
+++ b/octoprint_ws281x_led_status/effects/progress.py
@@ -13,8 +13,6 @@ def progress(strip, queue, value, progress_color, base_color, max_brightness=255
     upper_remainder, upper_whole = math.modf(upper_bar)
     lower_base = ((100 - value) / 100) * num_pixels
     lower_remainder, lower_whole = math.modf(lower_base)
-    if int(upper_bar + lower_base) != strip.numPixels():
-        log.info("Progress sanity check failed!, (bar)%s +  (base)%s = (total)%s != (strip)%s", upper_bar, lower_base, upper_bar + lower_base, strip.numPixels())
     for i in range(int(upper_whole)):
         strip.setPixelColorRGB(i, *progress_color)
     if upper_remainder:
@@ -22,6 +20,5 @@ def progress(strip, queue, value, progress_color, base_color, max_brightness=255
         strip.setPixelColorRGB(int(upper_whole), *tween_color)
     for i in range(int(lower_whole)):
         strip.setPixelColorRGB(((num_pixels - 1) - i), *base_color)
-    log.info('Show strip')
     strip.show()
     time.sleep(0.1)

--- a/octoprint_ws281x_led_status/effects/progress.py
+++ b/octoprint_ws281x_led_status/effects/progress.py
@@ -1,5 +1,6 @@
 # Print and heat up progress?
 from __future__ import absolute_import, unicode_literals, division
+import math
 import time
 
 from octoprint_ws281x_led_status.util import blend_two_colors
@@ -8,14 +9,19 @@ from octoprint_ws281x_led_status.util import blend_two_colors
 def progress(strip, queue, value, progress_color, base_color, max_brightness=255):
     strip.setBrightness(max_brightness)
     num_pixels = strip.numPixels()
-    upper_bar = int(round((value / 100) * num_pixels))
-    lower_base = int(round(((100 - value) / 100) * num_pixels))
-    if upper_bar + lower_base != strip.numPixels():
-        print("Progress sanity check failed!, (bar){} +  (base){} = (total){} != (strip){}".format(
-            upper_bar, lower_base, upper_bar + lower_base, strip.numPixels()))
-    for i in range(upper_bar):
+    upper_bar = (value / 100) * num_pixels
+    upper_remainder, upper_whole = math.modf(upper_bar)
+    lower_base = ((100 - value) / 100) * num_pixels
+    lower_remainder, lower_whole = math.modf(lower_base)
+    if int(upper_bar + lower_base) != strip.numPixels():
+        log.info("Progress sanity check failed!, (bar)%s +  (base)%s = (total)%s != (strip)%s", upper_bar, lower_base, upper_bar + lower_base, strip.numPixels())
+    for i in range(int(upper_whole)):
         strip.setPixelColorRGB(i, *progress_color)
-    for i in range(lower_base):
+    if upper_remainder:
+        tween_color = blend_two_colors(progress_color, base_color, upper_remainder)
+        strip.setPixelColorRGB(int(upper_whole), *tween_color)
+    for i in range(int(lower_whole)):
         strip.setPixelColorRGB(((num_pixels - 1) - i), *base_color)
+    log.info('Show strip')
     strip.show()
     time.sleep(0.1)

--- a/octoprint_ws281x_led_status/util.py
+++ b/octoprint_ws281x_led_status/util.py
@@ -9,13 +9,18 @@ def hex_to_rgb(h):
     return tuple(int(h[i:i+2], 16) for i in (0, 2, 4))
 
 
-def blend_two_colors(colour1, colour2):
+def blend_two_colors(colour1, colour2, percent_of_c1=None):
     """
     """
+    if percent_of_c1:
+        colour1 = [x * percent_of_c1 for x in colour1]
+        percent_of_c2 = 1 - percent_of_c1
+        colour2 = [x * percent_of_c2 for x in colour2]
+
     r = average(colour1[0], colour2[0])
     g = average(colour1[1], colour2[1])
     b = average(colour1[2], colour2[2])
-    return r, g, b
+    return tuple([int(r), int(g), int(b)])
 
 
 def average(a, b):


### PR DESCRIPTION
Instead of only changing LED on the percentage related to pixel_count, the next LED will display the percentage as a fade from base color to progress color.
```
Example:
   pixel_count = 10
   value = 55
   5 LEDs would be progress_color, the 6th would be 50% progress_color and 50% base_color, and the rest would be base_color
```