### PR TITLE
Emulate PixelStrip to send data to WLED

### DIFF
--- a/octoprint_ws281x_led_status/constants.py
+++ b/octoprint_ws281x_led_status/constants.py
@@ -55,6 +55,7 @@ STRIP_TYPES = {
     "SK6812_STRIP_GBRW": rpi_ws281x.SK6812_STRIP_GBRW,
     "SK6812_STRIP_BRGW": rpi_ws281x.SK6812_STRIP_BRGW,
     "SK6812_STRIP_BGRW": rpi_ws281x.SK6812_STRIP_BGRW,
+    "WLED_UDP": 0xFFFFFFFF,
 }
 EFFECTS = {
     "Solid Color": standard.solid_color,

--- a/octoprint_ws281x_led_status/runner.py
+++ b/octoprint_ws281x_led_status/runner.py
@@ -368,7 +368,7 @@ class EffectRunner:
                     invert=bool(self.strip_settings["invert"]),
                     brightness=int(self.strip_settings["brightness"]),
                     channel=int(self.strip_settings["channel"]),
-                    strip_type=constants.STRIP_TYPES[self.strip_settings["type"]],
+                    strip_type=strip_type,
                 )
             strip.begin()
             self._logger.info("Strip successfully initialised")

--- a/octoprint_ws281x_led_status/runner.py
+++ b/octoprint_ws281x_led_status/runner.py
@@ -33,6 +33,7 @@ from octoprint_ws281x_led_status.util import (
     start_daemon_thread,
     start_daemon_timer,
 )
+from octoprint_ws281x_led_status.wled_strip import WLEDStrip
 
 
 class EffectRunner:
@@ -350,16 +351,25 @@ class EffectRunner:
         """
         self._logger.info("Initialising LED strip")
         try:
-            strip = PixelStrip(
-                num=int(self.strip_settings["count"]),
-                pin=int(self.strip_settings["pin"]),
-                freq_hz=int(self.strip_settings["freq_hz"]),
-                dma=int(self.strip_settings["dma"]),
-                invert=bool(self.strip_settings["invert"]),
-                brightness=int(self.strip_settings["brightness"]),
-                channel=int(self.strip_settings["channel"]),
-                strip_type=constants.STRIP_TYPES[self.strip_settings["type"]],
-            )
+            strip_type = constants.STRIP_TYPES[self.strip_settings["type"]]
+            if strip_type == constants.STRIP_TYPES["WLED_UDP"]:
+                strip = WLEDStrip(
+                    int(self.strip_settings["count"]),
+                    self.strip_settings["wled_host"],
+                    int(self.strip_settings["wled_port"]),
+                    bool(self.strip_settings["white_override"]),
+                )
+            else:
+                strip = PixelStrip(
+                    num=int(self.strip_settings["count"]),
+                    pin=int(self.strip_settings["pin"]),
+                    freq_hz=int(self.strip_settings["freq_hz"]),
+                    dma=int(self.strip_settings["dma"]),
+                    invert=bool(self.strip_settings["invert"]),
+                    brightness=int(self.strip_settings["brightness"]),
+                    channel=int(self.strip_settings["channel"]),
+                    strip_type=constants.STRIP_TYPES[self.strip_settings["type"]],
+                )
             strip.begin()
             self._logger.info("Strip successfully initialised")
             return strip

--- a/octoprint_ws281x_led_status/settings.py
+++ b/octoprint_ws281x_led_status/settings.py
@@ -24,6 +24,8 @@ defaults = {
         "adjustment": {"R": 100, "G": 100, "B": 100},
         "white_override": False,
         "white_brightness": 50,
+        "wled_host": "4.3.2.1",
+        "wled_port": 21324,
     },
     "effects": {
         "startup": {

--- a/octoprint_ws281x_led_status/templates/settings_strip_modal.jinja2
+++ b/octoprint_ws281x_led_status/templates/settings_strip_modal.jinja2
@@ -49,6 +49,18 @@
                 </div>
             </div>
             <div class="control-group">
+                <label class="control-label">{{ _('WLED Host') }}</label>
+                <div class="controls">
+                    <input type="text" id="wled_host" class="input-medium" data-bind="value: settingsViewModel.settings.plugins.ws281x_led_status.strip.wled_host">
+                </div>
+            </div>
+            <div class="control-group">
+                <label class="control-label">{{ _('WLED Port') }}</label>
+                <div class="controls">
+                    <input type="number" id="wled_port" class="input-medium" data-bind="value: settingsViewModel.settings.plugins.ws281x_led_status.strip.wled_port">
+                </div>
+            </div>
+            <div class="control-group">
                 <label class="control-label">{{ _('GPIO pin') }}</label>
                 <div class="controls">
                     <input type="number" min="10" max="10" class="input-medium" data-bind="value: settingsViewModel.settings.plugins.ws281x_led_status.strip.pin">

--- a/octoprint_ws281x_led_status/wled_strip.py
+++ b/octoprint_ws281x_led_status/wled_strip.py
@@ -1,4 +1,4 @@
-from typing import Tuple, Optional
+from typing import Optional, Tuple
 
 import socket
 
@@ -13,7 +13,7 @@ class WLEDStrip:
     # Number of pixels to control
     _numPixels: int
     # If RGBW values are buffered and sent to WLED
-    _enableRGBW = False
+    _enableRGBW: bool
 
     # Address of WLED instance's UDP realtime control
     _addr: Tuple[str, int]
@@ -93,6 +93,7 @@ class WLEDStrip:
     def show(self):
         """Send the buffer to the strip."""
         if self._brightness != 255:
+            # Only recalculate brightness for pixel values, skip the additional data.
             values = bytes(
                 [
                     int(val * (self._brightness / 255))

--- a/octoprint_ws281x_led_status/wled_strip.py
+++ b/octoprint_ws281x_led_status/wled_strip.py
@@ -7,7 +7,7 @@ class WLEDStrip:
     """Emulates the PixelStrip class provided by rpi-ws281x but instead of
     outputing data to a local LED strip, it outputs data over UDP to WLED."""
 
-    # Magic bytes for WLED, specifies DRGB mode with a 5 second return delay.
+    # Magic bytes for WLED, specify control protocol and return delay.
     _CONTROL_BYTES: bytes
 
     # Number of pixels to control
@@ -39,6 +39,8 @@ class WLEDStrip:
         self._socket = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
         self._socket.settimeout(1.0)
 
+        # If using RGBW, we need to use WLED's DRGBW mode (3) instead of DRGB (2).
+        # We also specify that WLED shouldn't ever return to normal mode.
         if enableRGBW:
             self._CONTROL_BYTES = bytes([3, 255])
         else:

--- a/octoprint_ws281x_led_status/wled_strip.py
+++ b/octoprint_ws281x_led_status/wled_strip.py
@@ -1,0 +1,93 @@
+from typing import Tuple, Optional
+
+import socket
+
+
+class WLEDStrip:
+    """Emulates the PixelStrip class provided by rpi-ws281x but instead of
+    outputing data to a local LED strip, it outputs data over UDP to WLED."""
+
+    # Magic bytes for WLED, specifies DRGB mode with a 5 second return delay.
+    _CONTROL_BYTES: bytes
+
+    # Number of pixels to control
+    _numPixels: int
+    # If RGBW values are buffered and sent to WLED
+    _enableRGBW = False
+
+    # Address of WLED instance's UDP realtime control
+    _addr: Tuple[str, int]
+    # Socket used to connect to WLED
+    _socket: socket.socket
+
+    # Buffer of LED values to allow selective updates
+    _pixel_buffer: bytearray
+
+    def __init__(
+        self,
+        numPixels: int,
+        host: str,
+        port: int = 21324,
+        enableRGBW: bool = False,
+    ):
+        self._numPixels = numPixels
+        self._enableRGBW = enableRGBW
+
+        self._addr = (host, port)
+        self._socket = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+        self._socket.settimeout(1.0)
+
+        if enableRGBW:
+            self._CONTROL_BYTES = bytes([3, 5])
+        else:
+            self._CONTROL_BYTES = bytes([2, 5])
+
+        self._pixel_buffer = bytearray(
+            self._CONTROL_BYTES + bytes([0] * numPixels * self.bytesPerPixel)
+        )
+
+    @property
+    def bytesPerPixel(self) -> int:
+        """The number of bytes required to store each pixel.
+
+        This value is typically 3, but can be 4 if RGBW mode is enabled."""
+        return 4 if self._enableRGBW else 3
+
+    @property
+    def _pixelDataOffset(self) -> int:
+        """The offset in the data buffer to hold the control bytes."""
+        return len(self._CONTROL_BYTES)
+
+    def begin(self):
+        """Initialize the strip by displaying the buffer."""
+        self.show()
+
+    def numPixels(self):
+        """The number of pixels in the LED strip."""
+        return self._numPixels
+
+    def setBrightness(self, brightness: int):
+        """Control brightness for all pixels, currently not implemented."""
+        pass
+
+    def setPixelColorRGB(
+        self, index: int, red: int, green: int, blue: int, white: Optional[int] = None
+    ):
+        """Set the color of a single pixel at a specific index."""
+        if index > self._numPixels:
+            raise Exception("Invalid index")
+
+        if white:
+            if not self._enableRGBW:
+                raise Exception("White value was provided but RGBW was not enabled")
+
+            data = [red, green, blue, white]
+        else:
+            data = [red, green, blue]
+
+        start = self._pixelDataOffset + index * self.bytesPerPixel
+        self._pixel_buffer[start : start + self.bytesPerPixel] = data
+
+    def show(self):
+        """Send the buffer to the strip."""
+        self._socket.sendto(self._pixel_buffer, self._addr)

--- a/octoprint_ws281x_led_status/wled_strip.py
+++ b/octoprint_ws281x_led_status/wled_strip.py
@@ -38,9 +38,9 @@ class WLEDStrip:
         self._socket.settimeout(1.0)
 
         if enableRGBW:
-            self._CONTROL_BYTES = bytes([3, 5])
+            self._CONTROL_BYTES = bytes([3, 255])
         else:
-            self._CONTROL_BYTES = bytes([2, 5])
+            self._CONTROL_BYTES = bytes([2, 255])
 
         self._pixel_buffer = bytearray(
             self._CONTROL_BYTES + bytes([0] * numPixels * self.bytesPerPixel)


### PR DESCRIPTION
Hi there! This allows you to use WLED as a drop-in replacement. I'm not sure if this is a PR you're interested in, given there's a [separate plugin](https://github.com/cp2004/OctoPrint-WLED) for this feature.

The user configuration is definitely needing improvement still, but this is a working proof of concept that I'm using with my printer. Let me know if there's anything I'm missing. I've created this as a draft as it's a new and undiscussed feature, so definitely not ready to be merged yet.

Unrelated to this PR, it seems like this was an incorrect change: https://github.com/cp2004/OctoPrint-WS281x_LED_Status/commit/95ea39564fb89e12a7195d211f31fdaeca4a4447#diff-b098827de765c020bc5e911116065437e43da9db99cffec1b85c89e3b589fdf7R249. I had to change "effects" back to "effect" to make progress effects work. I didn't change it in this PR because it is an unrelated issue and I'm not sure if something else is going wrong there.