### PR TITLE
Adding ability to test a custom color from utils.

### DIFF
--- a/docs/documentation/rest-api.md
+++ b/docs/documentation/rest-api.md
@@ -36,7 +36,7 @@ Details of the plugin's current state
 
 ```javascript
 {
-  "lights_on": false, 
+  "lights_on": false,
   "torch_on": false
 }
 ```
@@ -77,7 +77,7 @@ The command to be sent to the plugin. See commands below.
 
 ```javascript
 {
-  "lights_on": false, 
+  "lights_on": false,
   "torch_on": false
 }
 ```
@@ -99,9 +99,8 @@ See also the [SimpleApi docs](https://docs.octoprint.org/en/devel/plugins/mixins
 | `torch_on` | None | Turn the torch mode on |
 | `torch_off` | None | Turn the torch mode off. Only available if torch mode is configured as toggle. |
 | `test_os_config` | None | Begin an OS configuration test. Asynchronous, data is returned on the socket |
-| `test_led` | `red`, `green`, `blue` | Set the LEDs to the configured RGB colour |
+| `test_led` | color | Set the LEDs to the configured HTML RGB colour |
 
 {% hint style="info" %}
 There are also API commands available for OS configuration options. However, it is not recommended that these are used by anything other than the plugin itself, so they are undocumented.
 {% endhint %}
-

--- a/octoprint_ws281x_led_status/api.py
+++ b/octoprint_ws281x_led_status/api.py
@@ -36,7 +36,7 @@ class PluginApi:
             CMD_TORCH_ON: [],
             CMD_TORCH_OFF: [],
             CMD_TEST_OS: [],
-            CMD_TEST_LED: ["red", "green", "blue"],
+            CMD_TEST_LED: ["color"],
             WIZ_ADDUSER: ["password"],
             WIZ_ENABLE_SPI: ["password"],
             WIZ_INCREASE_BUFFER: ["password"],
@@ -79,8 +79,9 @@ class PluginApi:
     def test_led(self, data):
         # We mock an M150 command here, because it is the easiest way
         # Calling update_effect skips the checking of M150 intercepting or the printer
-        self.plugin.update_effect(
-            "M150 R{} G{} B{}".format(
-                data.get("red"), data.get("green"), data.get("blue")
-            )
+        test_color = "M150 R{} G{} B{}".format(
+            util.hex_to_rgb(data.get("color"))[0],
+            util.hex_to_rgb(data.get("color"))[1],
+            util.hex_to_rgb(data.get("color"))[2]
         )
+        self.plugin.update_effect(test_color)

--- a/octoprint_ws281x_led_status/static/js/ws281x_led_status.js
+++ b/octoprint_ws281x_led_status/static/js/ws281x_led_status.js
@@ -154,12 +154,8 @@ $(function () {
             self.current_req(current.toString(10) + "A");
         };
 
-        self.sendTestCommand = function (red, green, blue) {
-            OctoPrint.simpleApiCommand("ws281x_led_status", "test_led", {
-                red: red,
-                green: green,
-                blue: blue,
-            });
+        self.sendTestCommand = function (color) {
+            OctoPrint.simpleApiCommand("ws281x_led_status", "test_led", { color } );
         };
 
         self.advancedStripOpen = ko.observable(false);

--- a/octoprint_ws281x_led_status/templates/settings/utilities.jinja2
+++ b/octoprint_ws281x_led_status/templates/settings/utilities.jinja2
@@ -1,15 +1,22 @@
+{% import "macros/binding.jinja2" as binding %}
 {% from "macros/docs.jinja2" import help_icon %}
 <h5>Utilities {{ help_icon("utilities")  }}</h5>
 
 <h5>LED Strip test</h5>
-<p>Provided so you can test the individual colours of your LED Strip.</p>
-<p>Can help to diagnose both hardware problems (Such as specific LEDs are broken), and help to select the correct strip type.</p>
+<p>Provided so you can test the individual colours of your LED Strip, and test specific color combinations.</p>
+<p>Can help to diagnose both hardware problems (Such as specific LEDs are broken), help to select the correct strip type, and allow you to see if you like certain colors for customizations.</p>
 <p>Sets LEDs to solid colour until the next event happens.</p>
-<button class="btn btn-danger" id="led-test-red" data-bind="click: function(){ sendTestCommand(255, 0, 0) }"><i class="far-custom fa-custom-lightbulb"></i> Test red</button>
-<button class="btn btn-success" id="led-test-green" data-bind="click: function(){ sendTestCommand(0, 255, 0) }"><i class="far-custom fa-custom-lightbulb"></i> Test green</button>
-<button class="btn btn-primary" id="led-test-blue" data-bind="click: function(){ sendTestCommand(0, 0, 255)}"><i class="far-custom fa-custom-lightbulb"></i> Test blue</button>
-<button class="btn" id="led-test-white" data-bind="click: function(){ sendTestCommand(255, 255, 255) }"><i class="far-custom fa-custom-lightbulb"></i> Test white</button>
-<br>
+<p>
+    <button class="btn btn-danger" id="led-test-red" data-bind="click: function(){ sendTestCommand('#ff0000') }"><i class="far-custom fa-custom-lightbulb"></i> Test red</button>
+    <button class="btn btn-success" id="led-test-green" data-bind="click: function(){ sendTestCommand('#00ff00') }"><i class="far-custom fa-custom-lightbulb"></i> Test green</button>
+    <button class="btn btn-primary" id="led-test-blue" data-bind="click: function(){ sendTestCommand('#0000ff') }"><i class="far-custom fa-custom-lightbulb"></i> Test blue</button>
+    <button class="btn" id="led-test-white" data-bind="click: function(){ sendTestCommand('#ffffff') }"><i class="far-custom fa-custom-lightbulb"></i> Test white</button>
+</p>
+<p>Sets LEDs to specific RGB colors until the next event happens.</p>
+<p>
+    <input id="ws_test_color" type="color" class="input-small">
+    <button class="btn" id="led-test-white" data-bind="click: function(){ sendTestCommand(document.querySelector('#ws_test_color').value) }"><i class="far-custom fa-custom-lightbulb"></i> Test Custom Color</button>
+</p>
 <hr>
 <h5>OS Config Test</h5>
 <p>Checks that the OS level configuration for SPI is correct, as per the initial setup wizard.</p>


### PR DESCRIPTION
- Added color selector and button to utils to allow testing specific RGB combos & updated verbiage.
- Made change to the test_led API to use HTML color codes instead of RGB.
- Updated API docs.