### PR TITLE
Allow building from wheel

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,4 +1,5 @@
 include README.md
+include LICENSE.txt
 include versioneer.py
 include octoprint_ws281x_led_status/_version.py
 recursive-include octoprint_ws281x_led_status/templates *


### PR DESCRIPTION
Related to #137. The wheel fails to build as the release.zip is missing `LICENSE.txt`.