### PR TITLE
Startup effect don't run sometimes

### DIFF
--- a/octoprint_ws281x_led_status/__init__.py
+++ b/octoprint_ws281x_led_status/__init__.py
@@ -84,6 +84,8 @@ class WS281xLedStatusPlugin(
 
         if self._settings.get_boolean(["lights_on"]):
             self.lights_on = True
+        elif self._settings.get_boolean(["effects", "idle", "enabled"]):
+            self.lights_on = True
         else:
             self.lights_on = False
 


### PR DESCRIPTION
If you shutdown octoprint while the printer is idle with the lights out, the startup effect don't show up.
Before adding this effect I would recommend to add some single run effects that don't repeat unendless.