### PR TITLE
🐛 Fix the URLs generated by docs.help_icon on the progress_effects page.

### DIFF
--- a/octoprint_ws281x_led_status/templates/settings/overview.jinja2
+++ b/octoprint_ws281x_led_status/templates/settings/overview.jinja2
@@ -1,4 +1,4 @@
-{% import "macros/binding.jinja2" as binding with context %}
+{% import "macros/binding.jinja2" as binding %}
 
 {% macro enabled_entry(setting, name) %}
 <div data-bind="visible: {{ binding.bind_setting(setting) }}">

--- a/octoprint_ws281x_led_status/templates/settings/progress_effects.jinja2
+++ b/octoprint_ws281x_led_status/templates/settings/progress_effects.jinja2
@@ -1,5 +1,5 @@
-{% import "macros/docs.jinja2" as docs %}
-{% import "macros/binding.jinja2" as binding with context %}
+{% import "macros/docs.jinja2" as docs  with context %}
+{% import "macros/binding.jinja2" as binding %}
 
 {% macro labelled_checkbox(setting, label) %}
 <label class="checkbox inline">


### PR DESCRIPTION
Without the `with context` the generated URL is relative to the octoprint server, as opposed to being on https://cp2004.gitbook.io/ws281x-led-status/.

It seems this was a mistake when this change was [originally made](https://github.com/bramp/OctoPrint-WS281x_LED_Status/commit/3648aa58815db2289a761b1cb14ed59486f32139). Additionally it seems overview.jinga2 has a `with context` where it doesn't need to be.