### PR TITLE
Fixes issue #209 and #210 by adding additional progress effects

### DIFF
--- a/octoprint_ws281x_led_status/constants.py
+++ b/octoprint_ws281x_led_status/constants.py
@@ -111,7 +111,7 @@ PROGRESS_EFFECTS = {
     "Progress Bar": progress.progress_bar,
     "Gradient": progress.gradient,
     "Single Pixel": progress.single_pixel,
-    "Both Ends": progress.both_ends,
+    "Both Ends": progress.progress_bar_from_both_ends(),
 }
 MODES = [
     "startup",

--- a/octoprint_ws281x_led_status/constants.py
+++ b/octoprint_ws281x_led_status/constants.py
@@ -109,6 +109,7 @@ EFFECTS = {
 }
 PROGRESS_EFFECTS = {
     "Progress Bar": progress.progress_bar,
+    "Reversed Progress Bar": progress.progress_bar_reversed,
     "Gradient": progress.gradient,
     "Single Pixel": progress.single_pixel,
     "Both Ends": progress.progress_bar_from_both_ends,

--- a/octoprint_ws281x_led_status/constants.py
+++ b/octoprint_ws281x_led_status/constants.py
@@ -111,7 +111,8 @@ PROGRESS_EFFECTS = {
     "Progress Bar": progress.progress_bar,
     "Gradient": progress.gradient,
     "Single Pixel": progress.single_pixel,
-    "Both Ends": progress.progress_bar_from_both_ends(),
+    "Both Ends": progress.progress_bar_from_both_ends,
+    "From Center": progress.progress_bar_from_center,
 }
 MODES = [
     "startup",

--- a/octoprint_ws281x_led_status/effects/progress.py
+++ b/octoprint_ws281x_led_status/effects/progress.py
@@ -21,34 +21,7 @@ def progress_bar(
     *args,
     **kwargs
 ):
-    brightness_manager.reset_brightness()
-    num_pixels = strip.numPixels()
-    upper_bar = (value / 100) * num_pixels
-    upper_remainder, upper_whole = math.modf(upper_bar)
-    pixels_remaining = num_pixels
-
-    for i in range(int(upper_whole)):
-        pixel = ((num_pixels - 1) - i) if reverse else i
-        strip.setPixelColorRGB(pixel, *progress_color)
-        pixels_remaining -= 1
-
-    if upper_remainder > 0.0:
-        tween_color = blend_two_colors(progress_color, base_color, upper_remainder)
-        pixel = ((num_pixels - int(upper_whole)) - 1) if reverse else int(upper_whole)
-        strip.setPixelColorRGB(pixel, *tween_color)
-        pixels_remaining -= 1
-
-    for i in range(pixels_remaining):
-        pixel = (
-            ((pixels_remaining - 1) - i)
-            if reverse
-            else ((num_pixels - pixels_remaining) + i)
-        )
-        strip.setPixelColorRGB(pixel, *base_color)
-
-    strip.show()
-    if not q_poll_sleep(0.1, queue):
-        return
+    progress_bar_impl(strip, queue, brightness_manager, value, progress_color, base_color, reverse, False)
 
 
 def gradient(
@@ -78,6 +51,64 @@ def single_pixel(
         strip.setPixelColorRGB(i, *base_color)
 
     strip.setPixelColorRGB(pixel_number, *progress_color)
+
+    strip.show()
+    if not q_poll_sleep(0.1, queue):
+        return
+
+
+def progress_bar_impl(
+    strip,
+    queue,
+    brightness_manager,
+    value,
+    progress_color,
+    base_color,
+    reverse,
+    half_strip,
+    *args,
+    **kwargs
+):
+    brightness_manager.reset_brightness()
+    num_pixels = strip.numPixels()
+    odd_pixel = 0
+    if num_pixels % 2 != 0:
+        odd_pixel = 1
+
+    def progress(min_pixel, max_pixel, val, reverse_progress):
+        number_pixels = max_pixel - min_pixel
+        upper_bar = (val / 100) * number_pixels
+        upper_remainder, upper_whole = math.modf(upper_bar)
+        pixels_remaining = number_pixels
+
+        for i in range(int(upper_whole)):
+            pixel = ((max_pixel - 1) - i) if reverse_progress else (min_pixel + i)
+            strip.setPixelColorRGB(pixel, *progress_color)
+            pixels_remaining -= 1
+
+        if upper_remainder > 0.0:
+            tween_color = blend_two_colors(progress_color, base_color, upper_remainder)
+            pixel = (
+                ((max_pixel - int(upper_whole)) - 1) if reverse_progress else (int(upper_whole) + min_pixel)
+            )
+            strip.setPixelColorRGB(pixel, *tween_color)
+            pixels_remaining -= 1
+
+        for i in range(pixels_remaining):
+            pixel = (
+                ((min_pixel + pixels_remaining - 1) - i)
+                if reverse_progress
+                else (min_pixel + (number_pixels - pixels_remaining) + i)
+            )
+            strip.setPixelColorRGB(pixel, *base_color)
+
+    if half_strip:
+        # Set the progress to either end of the strip
+        progress(0, math.floor(num_pixels / 2) + odd_pixel, value, True if reverse else False)
+        progress(math.ceil(num_pixels / 2) - odd_pixel, num_pixels, value, False if reverse else True)
+    else:
+        # Set the progress for the entire strip
+        progress(0, num_pixels, value, True if reverse else False)
 
     strip.show()
     if not q_poll_sleep(0.1, queue):

--- a/octoprint_ws281x_led_status/effects/progress.py
+++ b/octoprint_ws281x_led_status/effects/progress.py
@@ -24,6 +24,20 @@ def progress_bar(
     progress_bar_impl(strip, queue, brightness_manager, value, progress_color, base_color, reverse, False)
 
 
+def progress_bar_from_both_ends(
+    strip,
+    queue,
+    brightness_manager,
+    value,
+    progress_color,
+    base_color,
+    reverse,
+    *args,
+    **kwargs
+):
+    progress_bar_impl(strip, queue, brightness_manager, value, progress_color, base_color, reverse, True)
+
+
 def gradient(
     strip, queue, value, brightness_manager, progress_color, base_color, *args, **kwargs
 ):
@@ -109,61 +123,6 @@ def progress_bar_impl(
     else:
         # Set the progress for the entire strip
         progress(0, num_pixels, value, True if reverse else False)
-
-    strip.show()
-    if not q_poll_sleep(0.1, queue):
-        return
-
-
-def both_ends(
-    strip,
-    queue,
-    brightness_manager,
-    value,
-    progress_color,
-    base_color,
-    reverse,
-    *args,
-    **kwargs
-):
-    brightness_manager.reset_brightness()
-    num_pixels = strip.numPixels()
-    if num_pixels % 2 != 0:
-        num_pixels -= 1
-        # Set the unused pixel to off
-        strip.setPixelColorRGB(num_pixels, 0, 0, 0)
-
-    def progress(min_pixel, max_pixel, val, reverse_progress):
-        number_pixels = max_pixel - min_pixel
-        upper_bar = (val / 100) * number_pixels
-        upper_remainder, upper_whole = math.modf(upper_bar)
-        pixels_remaining = number_pixels
-
-        for i in range(int(upper_whole)):
-            pixel = ((max_pixel - 1) - i) if reverse_progress else (min_pixel + i)
-            strip.setPixelColorRGB(pixel, *progress_color)
-            pixels_remaining -= 1
-
-        if upper_remainder > 0.0:
-            tween_color = blend_two_colors(progress_color, base_color, upper_remainder)
-            pixel = (
-                ((max_pixel - int(upper_whole)) - 1) if reverse_progress else (int(upper_whole) + min_pixel)
-            )
-            strip.setPixelColorRGB(pixel, *tween_color)
-            pixels_remaining -= 1
-
-        for i in range(pixels_remaining):
-            pixel = (
-                ((min_pixel + pixels_remaining - 1) - i)
-                if reverse_progress
-                else (min_pixel + (number_pixels - pixels_remaining) + i)
-            )
-            strip.setPixelColorRGB(pixel, *base_color)
-
-    # Set the progress to either end of the strip
-
-    progress(0, num_pixels // 2, value, True if reverse else False)
-    progress(num_pixels // 2, num_pixels, value, False if reverse else True)
 
     strip.show()
     if not q_poll_sleep(0.1, queue):

--- a/octoprint_ws281x_led_status/effects/progress.py
+++ b/octoprint_ws281x_led_status/effects/progress.py
@@ -38,6 +38,19 @@ def progress_bar_from_both_ends(
     progress_bar_impl(strip, queue, brightness_manager, value, progress_color, base_color, reverse, True)
 
 
+def progress_bar_from_center(
+    strip,
+    queue,
+    brightness_manager,
+    value,
+    progress_color,
+    base_color,
+    *args,
+    **kwargs
+):
+    progress_bar_impl(strip, queue, brightness_manager, value, progress_color, base_color, True, True)
+
+
 def gradient(
     strip, queue, value, brightness_manager, progress_color, base_color, *args, **kwargs
 ):

--- a/octoprint_ws281x_led_status/effects/progress.py
+++ b/octoprint_ws281x_led_status/effects/progress.py
@@ -142,11 +142,11 @@ def progress_bar_impl(
 
     if half_strip:
         # Set the progress to either end of the strip
-        progress(0, math.floor(num_pixels / 2) + odd_pixel, value, True if reverse else False)
-        progress(math.ceil(num_pixels / 2) - odd_pixel, num_pixels, value, False if reverse else True)
+        progress(0, math.floor(num_pixels / 2) + odd_pixel, value, reverse)
+        progress(math.ceil(num_pixels / 2) - odd_pixel, num_pixels, value, not reverse)
     else:
         # Set the progress for the entire strip
-        progress(0, num_pixels, value, True if reverse else False)
+        progress(0, num_pixels, value, reverse)
 
     strip.show()
     if not q_poll_sleep(0.1, queue):

--- a/octoprint_ws281x_led_status/effects/progress.py
+++ b/octoprint_ws281x_led_status/effects/progress.py
@@ -17,11 +17,10 @@ def progress_bar(
     value,
     progress_color,
     base_color,
-    reverse,
     *args,
     **kwargs
 ):
-    progress_bar_impl(strip, queue, brightness_manager, value, progress_color, base_color, reverse, False)
+    progress_bar_impl(strip, queue, brightness_manager, value, progress_color, base_color, False, False)
 
 
 def progress_bar_from_both_ends(
@@ -31,11 +30,10 @@ def progress_bar_from_both_ends(
     value,
     progress_color,
     base_color,
-    reverse,
     *args,
     **kwargs
 ):
-    progress_bar_impl(strip, queue, brightness_manager, value, progress_color, base_color, reverse, True)
+    progress_bar_impl(strip, queue, brightness_manager, value, progress_color, base_color, False, True)
 
 
 def progress_bar_from_center(
@@ -49,6 +47,19 @@ def progress_bar_from_center(
     **kwargs
 ):
     progress_bar_impl(strip, queue, brightness_manager, value, progress_color, base_color, True, True)
+
+
+def progress_bar_reversed(
+    strip,
+    queue,
+    brightness_manager,
+    value,
+    progress_color,
+    base_color,
+    *args,
+    **kwargs
+):
+    progress_bar_impl(strip, queue, brightness_manager, value, progress_color, base_color, True, False)
 
 
 def gradient(

--- a/octoprint_ws281x_led_status/effects/progress.py
+++ b/octoprint_ws281x_led_status/effects/progress.py
@@ -85,7 +85,15 @@ def single_pixel(
 
 
 def both_ends(
-    strip, queue, brightness_manager, value, progress_color, base_color, *args, **kwargs
+    strip,
+    queue,
+    brightness_manager,
+    value,
+    progress_color,
+    base_color,
+    reverse,
+    *args,
+    **kwargs
 ):
     brightness_manager.reset_brightness()
     num_pixels = strip.numPixels()
@@ -94,21 +102,21 @@ def both_ends(
         # Set the unused pixel to off
         strip.setPixelColorRGB(num_pixels, 0, 0, 0)
 
-    def progress(min_pixel, max_pixel, val, reverse):
+    def progress(min_pixel, max_pixel, val, reverse_progress):
         number_pixels = max_pixel - min_pixel
         upper_bar = (val / 100) * number_pixels
         upper_remainder, upper_whole = math.modf(upper_bar)
         pixels_remaining = number_pixels
 
         for i in range(int(upper_whole)):
-            pixel = ((max_pixel - 1) - i) if reverse else i
+            pixel = ((max_pixel - 1) - i) if reverse_progress else (min_pixel + i)
             strip.setPixelColorRGB(pixel, *progress_color)
             pixels_remaining -= 1
 
         if upper_remainder > 0.0:
             tween_color = blend_two_colors(progress_color, base_color, upper_remainder)
             pixel = (
-                ((max_pixel - int(upper_whole)) - 1) if reverse else int(upper_whole)
+                ((max_pixel - int(upper_whole)) - 1) if reverse_progress else (int(upper_whole) + min_pixel)
             )
             strip.setPixelColorRGB(pixel, *tween_color)
             pixels_remaining -= 1
@@ -116,15 +124,15 @@ def both_ends(
         for i in range(pixels_remaining):
             pixel = (
                 ((min_pixel + pixels_remaining - 1) - i)
-                if reverse
-                else ((number_pixels - pixels_remaining) + i)
+                if reverse_progress
+                else (min_pixel + (number_pixels - pixels_remaining) + i)
             )
             strip.setPixelColorRGB(pixel, *base_color)
 
     # Set the progress to either end of the strip
 
-    progress(0, num_pixels // 2, value, False)
-    progress(num_pixels // 2, num_pixels, value, True)
+    progress(0, num_pixels // 2, value, True if reverse else False)
+    progress(num_pixels // 2, num_pixels, value, False if reverse else True)
 
     strip.show()
     if not q_poll_sleep(0.1, queue):

--- a/octoprint_ws281x_led_status/runner/__init__.py
+++ b/octoprint_ws281x_led_status/runner/__init__.py
@@ -341,7 +341,6 @@ class EffectRunner:
                     "base_color": apply_color_correction(
                         self.color_correction, *hex_to_rgb(effect_settings["base"])
                     ),
-                    "reverse": self.strip_settings["reverse"],
                 },
                 name=mode,
             )

--- a/octoprint_ws281x_led_status/settings.py
+++ b/octoprint_ws281x_led_status/settings.py
@@ -18,7 +18,6 @@ defaults = {
         "dma": 10,
         "invert": False,
         "channel": 0,
-        "reverse": False,
         "type": "WS2811_STRIP_GRB",
         "brightness": 50,
         "adjustment": {"R": 100, "G": 100, "B": 100},
@@ -142,6 +141,10 @@ def migrate_settings(target, current, settings):
         # 1 => 2
         migrate_one_to_two(settings)
 
+    if (current is None or current <= 2) and target == 3:
+        # 2 => 3
+        migrate_two_to_three(settings)
+
 
 def migrate_none_to_one(settings):
     new_settings = {
@@ -262,6 +265,22 @@ def migrate_one_to_two(settings):
     settings.settings.remove(["plugins", "ws281x_led_status", "at_command_reaction"])
     settings.settings.remove(["plugins", "ws281x_led_status", "intercept_m150"])
     settings.settings.remove(["plugins", "ws281x_led_status", "debug_logging"])
+
+
+def migrate_two_to_three(settings):
+    # See PR #212 for changes
+    reverse = settings.get(["strip", "reverse"])
+
+    if reverse and settings.get(["effects", "progress_print", "effect"]) == "Progress Bar":
+        settings.set(["effects", "progress_print", "effect"], "Progress Bar Reversed")
+
+    if reverse and settings.get(["effects", "progress_heatup", "effect"]) == "Progress Bar":
+        settings.set(["effects", "progress_heatup", "effect"], "Progress Bar Reversed")
+
+    if reverse and settings.get(["effects", "progress_cooling", "effect"]) == "Progress Bar":
+        settings.set(["effects", "progress_cooling", "effect"], "Progress Bar Reversed")
+
+    settings.settings.remove(["plugins", "ws281x_led_status", "strip", "reverse"])
 
 
 def filter_none(target):

--- a/octoprint_ws281x_led_status/templates/settings/progress_effects.jinja2
+++ b/octoprint_ws281x_led_status/templates/settings/progress_effects.jinja2
@@ -27,8 +27,6 @@
 
 <h5>Progress effects {{ docs.help_icon("configuration/progress-effects") }}</h5>
 <form class="form-horizontal">
-    {{ labelled_checkbox("strip.reverse", "Reverse progress bar direction") }}
-    <hr>
     {{ labelled_checkbox("effects.progress_print.enabled", "Enable Printing Progress") }}
     <div class="form-inline" data-bind="visible: {{ binding.effect_binding("progress_print.enabled") }}">
         {{ effect_select("progress_print") }}


### PR DESCRIPTION
~~Note that this fix does not include my changes for issue #209. I wasn't sure how you preferred PRs so they are completely separate and will need to be merged appropriately.~~

~~This change would also allow offsets to be added to the `Both Ends` progress effect if that was a future enhancement that was desired as there is no longer an assumption of LED 0 being a start point and all traversal is based on the actual `min_pixel` and `max_pixel` values passed to the `progress` function.~~

See discussion below for the implemented solution.