### PR TITLE
Update spi-setup.md to fix typo in buffer size explanation

### DIFF
--- a/docs/guides/setup-guide-1/spi-setup.md
+++ b/docs/guides/setup-guide-1/spi-setup.md
@@ -26,7 +26,7 @@ The setup wizard requires root access, and therefore the password for the Pi use
 * **Enable SPI.** The plugin uses SPI to drive the LEDs, which is disabled by default and needs to be turned on.
   * Adds `dtparam=spi=on` to `/boot/config.txt`
 * **Increase SPI buffer size.** Whilst the plugin will work without this, it will only work well with a handful of LEDs, so the buffer size must be increased to control more LEDs.
-  * Adds `spidev.bufsize=32768` to the end of `/boot/cmdline.txt`
+  * Adds `spidev.bufsiz=32768` to the end of `/boot/cmdline.txt`
 * **Set compatible clock frequency** _Raspberry Pi 3 or earlier only, not required for a Pi 4_ The Pi 3's default internal clock frequency is not compatible with SPI, so it needs to be set to 250 to be compatible.
   * Adds `core_freq=250` to `/boot/config.txt`
 * **Set a minimum clock frequency** _Raspberry Pi 4 only_ On a Raspberry Pi 4, the clock frequency is dynamic and can change when the pi is 'idle' vs. 'working', which causes LEDs to flicker, change colour, or stop working completely. By setting a minimum the same as the max, we stop this dynamic clocking.


### PR DESCRIPTION
The buffer size explanation had a typo in the attribute to be added to `cmdline.txt` where it says `spidev.bufsize` instead of `spidev.bufsiz`